### PR TITLE
Remove deprecated rules from PHP-CS-Fixer config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ composer.lock
 # For PHPUnit
 /build
 /phpunit*.xml
+.phpunit.result.cache
 # For Tests
 /tests/output/*
 !/tests/output/.gitkeep

--- a/.php_cs
+++ b/.php_cs
@@ -4,9 +4,9 @@ $header = <<<'EOF'
 Jasper report integration for PHP
 
 @link      https://github.com/belgattitude/soluble-jasper
-@author    Vanvelthem Sébastien 
+@author    Vanvelthem Sébastien
 @copyright Copyright (c) 2017 Vanvelthem Sébastien
-@license   MIT   
+@license   MIT
 EOF;
 
 return PhpCsFixer\Config::create()
@@ -39,15 +39,16 @@ return PhpCsFixer\Config::create()
             'align_equals' => true,
         ],
         'blank_line_after_opening_tag' => true,
-        'blank_line_before_return' => true,
+        'blank_line_before_statement' => true,
         'cast_spaces' => true,
         'class_definition' => ['singleLine' => true],
         'concat_space' => ['spacing' => 'one'], // Different from symfony (none)
         'declare_equal_normalize' => true,
+        'error_suppression' => true,
         'function_typehint_space' => true,
-        'hash_to_slash_comment' => true,
         'heredoc_to_nowdoc' => true,
         'include' => true,
+        'increment_style' => true,
         'lowercase_cast' => true,
         'mb_str_functions' => true,
         'method_separation' => true,
@@ -59,13 +60,15 @@ return PhpCsFixer\Config::create()
         'no_empty_comment' => true,
         'no_empty_phpdoc' => true,
         'no_empty_statement' => true,
-        'no_extra_consecutive_blank_lines' => [
-            'curly_brace_block',
-            'extra',
-            'parenthesis_brace_block',
-            'square_brace_block',
-            'throw',
-            'use',
+        'no_extra_blank_lines' => [ 'tokens' =>
+            [
+                'curly_brace_block',
+                'extra',
+                'parenthesis_brace_block',
+                'square_brace_block',
+                'throw',
+                'use',
+            ]
         ],
         'no_leading_import_slash' => true,
         'no_leading_namespace_whitespace' => true,
@@ -100,12 +103,12 @@ return PhpCsFixer\Config::create()
         'phpdoc_trim' => true,
         'phpdoc_types' => true,
         'phpdoc_var_without_name' => true,
-        'pre_increment' => true,
         'return_type_declaration' => true,
         'self_accessor' => true,
         'short_scalar_cast' => true,
         'single_blank_line_before_namespace' => true,
         'single_class_element_per_statement' => true,
+        'single_line_comment_style' => true,
         'single_quote' => true,
         'space_after_semicolon' => true,
         'standardize_not_equals' => true,
@@ -120,7 +123,6 @@ return PhpCsFixer\Config::create()
         'php_unit_construct' => true,
         'php_unit_dedicate_assert' => true,
         'php_unit_fqcn_annotation' => true,
-        'silenced_deprecation_error' => true,
         'declare_strict_types' => true,
 
     ])
@@ -130,4 +132,3 @@ return PhpCsFixer\Config::create()
             ->in(['src', 'tests'])
     )
 ;
-

--- a/src/Exporter/PDFExporter.php
+++ b/src/Exporter/PDFExporter.php
@@ -92,6 +92,7 @@ class PDFExporter
             if (file_exists($tmpFile)) {
                 unlink($tmpFile);
             }
+
             throw $e;
         }
 
@@ -134,6 +135,7 @@ class PDFExporter
         }
         if (chmod($tmpFile, $mode) === false) {
             unlink($tmpFile);
+
             throw new IOPermissionException(sprintf(
                 'Cannot set file permission of file %s.',
                 $tmpFile

--- a/src/Proxy/Data/JsonDataAdapterImpl.php
+++ b/src/Proxy/Data/JsonDataAdapterImpl.php
@@ -90,10 +90,12 @@ class JsonDataAdapterImpl implements RemoteJavaObjectProxyInterface
         switch (mb_strtolower($language)) {
             case 'json':
                 $lang = $jsonExpressionLanguageEnum->JSON;
+
                 break;
 
             case 'jsonql':
                 $lang = $jsonExpressionLanguageEnum->JSONQL;
+
                 break;
             default:
                 throw new Exception\InvalidArgumentException(sprintf(

--- a/src/ReportParams.php
+++ b/src/ReportParams.php
@@ -34,6 +34,7 @@ class ReportParams implements \ArrayAccess, \IteratorAggregate
     public function __construct(iterable $params = [])
     {
         $this->params = new ArrayObject();
+
         try {
             foreach ($params as $key => $value) {
                 $current_key = $key;

--- a/src/Runner/BridgedReportRunner.php
+++ b/src/Runner/BridgedReportRunner.php
@@ -87,6 +87,7 @@ class BridgedReportRunner implements ReportRunnerInterface
                     $e->getMessage()
                 )
             );
+
             throw $e;
         }
 
@@ -163,6 +164,7 @@ class BridgedReportRunner implements ReportRunnerInterface
                     $e->getMessage()
                 )
             );
+
             throw $e;
         }
     }

--- a/tests/bench/simple_benchmarks.php
+++ b/tests/bench/simple_benchmarks.php
@@ -61,6 +61,7 @@ echo '<pre>' . PHP_EOL;
 
 // BENCHING CONNECTION
 $start_connection_time = $bm->getTimeMs();
+
 try {
     $ba = new BridgeAdapter([
         'driver'             => 'Pjb62',

--- a/tests/functional/Recipes/JasperCompileManagerTest.php
+++ b/tests/functional/Recipes/JasperCompileManagerTest.php
@@ -67,6 +67,7 @@ class JasperCompileManagerTest extends TestCase
         chmod($outputFile, 0400);
 
         $saved = false;
+
         try {
             $compileManager->compileReportToFile($reportFile, $outputFile);
             // Must throw exception, this code cannot be reached !!!

--- a/tests/server/expressive/config/pipeline.php
+++ b/tests/server/expressive/config/pipeline.php
@@ -15,9 +15,7 @@ use Zend\Expressive\Router\Middleware\MethodNotAllowedMiddleware;
 use Zend\Expressive\Router\Middleware\RouteMiddleware;
 use Zend\Stratigility\Middleware\ErrorHandler;
 
-/*
- * Setup middleware pipeline:
- */
+// Setup middleware pipeline:
 return function (Application $app, MiddlewareFactory $factory, ContainerInterface $container): void {
     // The error handler should be the first (most outer) middleware to catch
     // all Exceptions.

--- a/tests/server/expressive/config/routes.php
+++ b/tests/server/expressive/config/routes.php
@@ -34,12 +34,14 @@ return function (Application $app, MiddlewareFactory $factory, ContainerInterfac
                         ->withBody(new Stream("$dataPath/northwind.xml"))
                         ->withHeader('content-type', 'application/xml')
                         ->withStatus(200);
+
                     break;
                 case 'json':
                     $response = (new Response())
                         ->withBody(new Stream("$dataPath/northwind.json"))
                         ->withHeader('content-type', 'application/json')
                         ->withStatus(200);
+
                     break;
                 default:
                     $response = (new TextResponse('Error'))->withStatus(500);

--- a/tests/server/expressive/public/index.php
+++ b/tests/server/expressive/public/index.php
@@ -10,9 +10,7 @@ if (PHP_SAPI === 'cli-server' && $_SERVER['SCRIPT_FILENAME'] !== __FILE__) {
 chdir(dirname(__DIR__));
 require 'vendor/autoload.php';
 
-/*
- * Self-called anonymous function that creates its own scope and keep the global namespace clean.
- */
+// Self-called anonymous function that creates its own scope and keep the global namespace clean.
 (function () {
     /** @var \Psr\Container\ContainerInterface $container */
     $container = require 'config/container.php';


### PR DESCRIPTION
Hello,

When I looked at your project (from r/php) I found this file at the root: `.php_cs`. Turns out I didn't know PHP-CS-Fixer existed! So thanks for that.

While setting up my project (starting with your config as a base), I found that you were using some deprecated rules.

So as a token of my gratitude for introducing me (although involontarily) to this great project, here is a humble PR that removes the deprecated rules in favor of their modern equivalent, with very minimal code change as a result.

And congrats on the overall code quality! It's impressive oO